### PR TITLE
Add support for vimwiki

### DIFF
--- a/colors/lighthaus.vim
+++ b/colors/lighthaus.vim
@@ -349,12 +349,12 @@ call s:h("sqlSpecial",    s:orange2,    "",   "")
 " ― ― ― ― ― ― ― ― ― 
 " ―  VIMWIKI ― 
 " ― ― ― ― ― ― ― ― ― 
-call s:h("VimwikiHeader1",   s:blue,    "",   s:B)
-call s:h("VimwikiHeader2",   s:orange,  "",   s:B)
-call s:h("VimwikiHeader3",   s:green,   "",   s:B)
+call s:h("VimwikiHeader1",   s:fg_alt,  "",   s:B)
+call s:h("VimwikiHeader2",   s:green,   "",   s:B)
+call s:h("VimwikiHeader3",   s:orange,  "",   s:B)
 call s:h("VimwikiHeader4",   s:purple,  "",   s:B)
 call s:h("VimwikiHeader5",   s:cyan,    "",   s:B)
-call s:h("VimwikiHeader6",   s:red,     "",   s:B)
+call s:h("VimwikiHeader6",   s:blue,    "",   s:B)
 
 " + + + + + + + + + PLUGINS + + + + + + + + +
 

--- a/colors/lighthaus.vim
+++ b/colors/lighthaus.vim
@@ -346,6 +346,15 @@ call s:h("sqlKeyword",    s:cyan2,      "",   "")
 call s:h("sqlSpecial",    s:orange2,    "",   "")
 " }
 
+" ― ― ― ― ― ― ― ― ― 
+" ―  VIMWIKI ― 
+" ― ― ― ― ― ― ― ― ― 
+call s:h("VimwikiHeader1",   s:blue,    "",   s:B)
+call s:h("VimwikiHeader2",   s:orange,  "",   s:B)
+call s:h("VimwikiHeader3",   s:green,   "",   s:B)
+call s:h("VimwikiHeader4",   s:purple,  "",   s:B)
+call s:h("VimwikiHeader5",   s:cyan,    "",   s:B)
+call s:h("VimwikiHeader6",   s:red,     "",   s:B)
 
 " + + + + + + + + + PLUGINS + + + + + + + + +
 

--- a/colors/lighthaus.vim
+++ b/colors/lighthaus.vim
@@ -346,15 +346,6 @@ call s:h("sqlKeyword",    s:cyan2,      "",   "")
 call s:h("sqlSpecial",    s:orange2,    "",   "")
 " }
 
-" ― ― ― ― ― ― ― ― ― 
-" ―  VIMWIKI ― 
-" ― ― ― ― ― ― ― ― ― 
-call s:h("VimwikiHeader1",   s:fg_alt,  "",   s:B)
-call s:h("VimwikiHeader2",   s:green,   "",   s:B)
-call s:h("VimwikiHeader3",   s:orange,  "",   s:B)
-call s:h("VimwikiHeader4",   s:purple,  "",   s:B)
-call s:h("VimwikiHeader5",   s:cyan,    "",   s:B)
-call s:h("VimwikiHeader6",   s:blue,    "",   s:B)
 
 " + + + + + + + + + PLUGINS + + + + + + + + +
 
@@ -554,9 +545,21 @@ call s:h("plugDeleted",   s:red,      "",   "")
 " ― ― ― ― ― ― ― ― ― 
 " {
 call s:h("SignatureMarkText",   s:hl_orange,    "",   "")
-
-
 " }
+
+
+" ― ― ― ― ― ― ― ― ― 
+" ―  VIMWIKI ― 
+" https://github.com/vimwiki/vimwiki
+" ― ― ― ― ― ― ― ― ― 
+call s:h("VimwikiHeader1",   s:hl_yellow,   "",   s:B)
+call s:h("VimwikiHeader2",   s:green,       "",   s:B)
+call s:h("VimwikiHeader3",   s:orange2,     "",   s:B)
+call s:h("VimwikiHeader4",   s:purple,      "",   s:B)
+call s:h("VimwikiHeader5",   s:cyan,        "",   s:B)
+call s:h("VimwikiHeader6",   s:white,       "",   s:B)
+
+
 " ― ― ― ― ― ― ― ― ― 
 " NEOVIM COLOR BUFFER
 " ― ― ― ― ― ― ― ― ― 


### PR DESCRIPTION
Vimwiki by default uses `hl-Title` for coloring the Headers, which is grey and not bold in lighthaus.