### PR TITLE
Use proper highlight group for TS variables

### DIFF
--- a/colors/lighthaus.vim
+++ b/colors/lighthaus.vim
@@ -531,9 +531,9 @@ hi link TSConstant Constant
 hi link TSFloat Float
 hi link TSString String
 hi link TSNumber Number
+hi link TSVariable Identifier
+hi link TSVariableBuiltin Identifier
 call s:h("TSStringRegex",       s:cyan2,      "",   "")
-call s:h("TSVariable",          s:blue2,      "",   "")
-call s:h("TSVariableBuiltin",   s:blue2,      "",   "")
 
 hi link TSError ErrorMsg
 hi link TSException Exception


### PR DESCRIPTION
__Related task:__ #7 

Treesitter highlight groups for variables were specified by hand.
Now they’re linked to the proper `Identifier` group. See the difference in images below. 

| C Before | C After |
|---|---|
| ![before_c](https://user-images.githubusercontent.com/77539239/178674095-46b57706-e6dd-4c5c-a071-83d0f93b0ff9.png) | ![after_c](https://user-images.githubusercontent.com/77539239/178674120-88d54b86-4a64-4de2-8c67-97480c1ff9ee.png) |

| Lua before | Lua after |
|---|---|
|![before_lua](https://user-images.githubusercontent.com/77539239/178674924-d0aab77f-d6b9-49c9-a97b-ab78e796b1fc.png)|![after_lua](https://user-images.githubusercontent.com/77539239/178674949-2cac44e2-0059-4ff4-a633-f26cb706f228.png)|

